### PR TITLE
Fix property element namespace prefixes

### DIFF
--- a/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
+++ b/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
@@ -1667,6 +1667,13 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 					    || (elementDeclaration.Type != null && declaration.Type != null && elementDeclaration.Type.IsSubclassOf(declaration.Type)))
 						return String.Empty;
 				}
+				else if (node is XmlBamlPropertyElement)
+				{
+					XmlBamlPropertyElement property = (XmlBamlPropertyElement)node;
+					declaration = property.TypeDeclaration;
+					if (property.Parent.TypeDeclaration.Type.IsSubclassOf(property.PropertyDeclaration.DeclaringType.Type))
+						declaration = property.Parent.TypeDeclaration;
+				}
 				else if (node is XmlBamlElement)
 					declaration = ((XmlBamlElement)node).TypeDeclaration;
 				else

--- a/ILSpy.BamlDecompiler/Tests/Cases/CustomControl.cs
+++ b/ILSpy.BamlDecompiler/Tests/Cases/CustomControl.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace ILSpy.BamlDecompiler.Tests.Cases
+{
+	public class CustomControl : Control
+	{
+	}
+}

--- a/ILSpy.BamlDecompiler/Tests/Cases/CustomControl.cs
+++ b/ILSpy.BamlDecompiler/Tests/Cases/CustomControl.cs
@@ -3,11 +3,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace ILSpy.BamlDecompiler.Tests.Cases
 {
-	public class CustomControl : Control
+	public class CustomControl : ContentControl
 	{
+		public static readonly DependencyProperty CustomNameProperty = DependencyProperty.RegisterAttached("CustomName", typeof(string), typeof(CustomControl));
+		
+		public static string GetCustomName(DependencyObject target)
+		{
+			return (string)target.GetValue(CustomNameProperty);
+		}
+		
+		public static void SetCustomName(DependencyObject target, string value)
+		{
+			target.SetValue(CustomNameProperty, value);
+		}
 	}
 }

--- a/ILSpy.BamlDecompiler/Tests/Cases/NamespacePrefix.xaml
+++ b/ILSpy.BamlDecompiler/Tests/Cases/NamespacePrefix.xaml
@@ -1,12 +1,16 @@
 ﻿<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:cc="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases">
-	<Label>
-		<Label.Style>
-			<Style />
-		</Label.Style>
-	</Label>
 	<cc:CustomControl>
 		<cc:CustomControl.Style>
 			<Style />
 		</cc:CustomControl.Style>
+		<Grid.Row>0</Grid.Row>
+		<cc:CustomControl.CustomName>Custom1</cc:CustomControl.CustomName>
 	</cc:CustomControl>
+	<Label>
+		<Label.Style>
+			<Style />
+		</Label.Style>
+		<Grid.Row>0</Grid.Row>
+		<cc:CustomControl.CustomName>Label1</cc:CustomControl.CustomName>
+	</Label>
 </Grid>

--- a/ILSpy.BamlDecompiler/Tests/Cases/NamespacePrefix.xaml
+++ b/ILSpy.BamlDecompiler/Tests/Cases/NamespacePrefix.xaml
@@ -1,0 +1,12 @@
+﻿<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:cc="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases">
+	<Label>
+		<Label.Style>
+			<Style />
+		</Label.Style>
+	</Label>
+	<cc:CustomControl>
+		<cc:CustomControl.Style>
+			<Style />
+		</cc:CustomControl.Style>
+	</cc:CustomControl>
+</Grid>

--- a/ILSpy.BamlDecompiler/Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler/Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -74,6 +74,7 @@
       <DependentUpon>AttachedEvent.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Cases\CustomControl.cs" />
     <Compile Include="Cases\MyControl.xaml.cs">
       <DependentUpon>MyControl.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -127,6 +128,7 @@
     <Page Include="Cases\AvalonDockCommon.xaml" />
     <Page Include="Cases\MarkupExtension.xaml" />
     <Page Include="Cases\MyControl.xaml" />
+    <Page Include="Cases\NamespacePrefix.xaml" />
     <Page Include="Cases\Resources.xaml" />
     <Page Include="Cases\Simple.xaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/ILSpy.BamlDecompiler/Tests/TestRunner.cs
+++ b/ILSpy.BamlDecompiler/Tests/TestRunner.cs
@@ -79,6 +79,12 @@ namespace ILSpy.BamlDecompiler.Tests
 			RunTest("cases/simplepropertyelement");
 		}
 		
+		[Test]
+		public void NamespacePrefix()
+		{
+			RunTest("cases/namespaceprefix");
+		}
+		
 		#region RunTest
 		void RunTest(string name)
 		{


### PR DESCRIPTION
The baml decompiler's logic for determining namespace prefixes on property elements was out of sync with the logic for determining local names. This resulted in some invalid xaml.
